### PR TITLE
fix(messages): handle new Discord message types

### DIFF
--- a/delete_me_discord/type_enums.py
+++ b/delete_me_discord/type_enums.py
@@ -1,4 +1,8 @@
+import logging
 from enum import IntEnum
+
+
+logger = logging.getLogger("MessageType")
 
 # Added from https://docs.discord.food/resources/message
 # https://discordhttp.alexflipnote.dev/api/enums.html#discord_http.enums.MessageType.custom_gift
@@ -11,10 +15,10 @@ class MessageType(IntEnum):
     CHANNEL_ICON_CHANGE = 5, False
     CHANNEL_PINNED_MESSAGE = 6, True
     USER_JOIN = 7, True
-    GUILD_BOOST = 8, True
-    GUILD_BOOST_TIER_1 = 9, True
-    GUILD_BOOST_TIER_2 = 10, True
-    GUILD_BOOST_TIER_3 = 11, True
+    PREMIUM_GUILD_SUBSCRIPTION = 8, True
+    PREMIUM_GUILD_SUBSCRIPTION_TIER_1 = 9, True
+    PREMIUM_GUILD_SUBSCRIPTION_TIER_2 = 10, True
+    PREMIUM_GUILD_SUBSCRIPTION_TIER_3 = 11, True
     CHANNEL_FOLLOW_ADD = 12, True
     # GUILD_STREAM = 13, True  # Deprecated/unused per docs.discord.food.
     GUILD_DISCOVERY_DISQUALIFIED = 14, True
@@ -27,7 +31,7 @@ class MessageType(IntEnum):
     THREAD_STARTER_MESSAGE = 21, False
     GUILD_INVITE_REMINDER = 22, True
     CONTEXT_MENU_COMMAND = 23, True
-    AUTO_MODERATION_ACTION = 24, False  # Requires special permissions
+    AUTO_MODERATION_ACTION = 24, False  # Discord requires MANAGE_MESSAGES permission.
     ROLE_SUBSCRIPTION_PURCHASE = 25, True
     INTERACTION_PREMIUM_UPSELL = 26, True
     STAGE_START = 27, True
@@ -38,7 +42,7 @@ class MessageType(IntEnum):
     GUILD_APPLICATION_PREMIUM_SUBSCRIPTION = 32, True
     # PRIVATE_CHANNEL_INTEGRATION_ADDED = 33, False  # Deprecated/unused per docs.discord.food.
     # PRIVATE_CHANNEL_INTEGRATION_REMOVED = 34, False  # Deprecated/unused per docs.discord.food.
-    PREMIUM_REFERRAL = 35, True
+    PREMIUM_REFERRAL = 35, False
     GUILD_INCIDENT_ALERT_MODE_ENABLED = 36, True
     GUILD_INCIDENT_ALERT_MODE_DISABLED = 37, True
     GUILD_INCIDENT_REPORT_RAID = 38, True
@@ -66,13 +70,34 @@ class MessageType(IntEnum):
     REPORT_TO_MOD_KICK_USER = 60, True
     REPORT_TO_MOD_BAN_USER = 61, True
     REPORT_TO_MOD_CLOSED_REPORT = 62, True
-    EMOJI_ADDED = 63, True
+    EMOJI_ADDED = 63, True  # Deprecated; retained for historical messages.
+    PREMIUM_GROUP_INVITE = 64, False
+    VOICE_SESSION = 65, True
+    GUILD_BOOST_UPSELL = 66, True
+    FRIEND_REQUEST_ACCEPTED = 67, True
+    MEDIA_MENTION_MESSAGE = 68, True
 
     def __new__(cls, value: int, deletable: bool):
         obj = int.__new__(cls, value)
         obj._value_ = value
         obj._deletable = deletable
         return obj
+
+    @classmethod
+    def _missing_(cls, value):
+        """Represent unknown numeric types conservatively instead of aborting a clean."""
+        if not isinstance(value, int):
+            return None
+
+        logger.warning(
+            "Discord returned unrecognized message type %s; treating this message as non-deletable.",
+            value,
+        )
+        message_type = int.__new__(cls, value)
+        message_type._name_ = f"UNKNOWN_{value}"
+        message_type._value_ = value
+        message_type._deletable = False
+        return message_type
 
     @property
     def deletable(self):

--- a/test/test_api_fetch_message.py
+++ b/test/test_api_fetch_message.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -147,6 +148,114 @@ def test_fetch_messages_paginates_and_respects_before(monkeypatch):
     assert [m["message_id"] for m in messages] == ["200", "150"]
     assert calls[0] == {"limit": 100}
     assert calls[1]["before"] == "150"
+
+
+@pytest.mark.parametrize(
+    ("value", "name", "deletable"),
+    [
+        (0, "DEFAULT", True),
+        (1, "RECIPIENT_ADD", False),
+        (2, "RECIPIENT_REMOVE", False),
+        (3, "CALL", False),
+        (4, "CHANNEL_NAME_CHANGE", False),
+        (5, "CHANNEL_ICON_CHANGE", False),
+        (6, "CHANNEL_PINNED_MESSAGE", True),
+        (7, "USER_JOIN", True),
+        (8, "PREMIUM_GUILD_SUBSCRIPTION", True),
+        (9, "PREMIUM_GUILD_SUBSCRIPTION_TIER_1", True),
+        (10, "PREMIUM_GUILD_SUBSCRIPTION_TIER_2", True),
+        (11, "PREMIUM_GUILD_SUBSCRIPTION_TIER_3", True),
+        (12, "CHANNEL_FOLLOW_ADD", True),
+        (14, "GUILD_DISCOVERY_DISQUALIFIED", True),
+        (15, "GUILD_DISCOVERY_REQUALIFIED", True),
+        (16, "GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING", True),
+        (17, "GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING", True),
+        (18, "THREAD_CREATED", True),
+        (19, "REPLY", True),
+        (20, "CHAT_INPUT_COMMAND", True),
+        (21, "THREAD_STARTER_MESSAGE", False),
+        (22, "GUILD_INVITE_REMINDER", True),
+        (23, "CONTEXT_MENU_COMMAND", True),
+        (24, "AUTO_MODERATION_ACTION", False),
+        (25, "ROLE_SUBSCRIPTION_PURCHASE", True),
+        (26, "INTERACTION_PREMIUM_UPSELL", True),
+        (27, "STAGE_START", True),
+        (28, "STAGE_END", True),
+        (29, "STAGE_SPEAKER", True),
+        (30, "STAGE_RAISE_HAND", True),
+        (31, "STAGE_TOPIC", True),
+        (32, "GUILD_APPLICATION_PREMIUM_SUBSCRIPTION", True),
+        (35, "PREMIUM_REFERRAL", False),
+        (36, "GUILD_INCIDENT_ALERT_MODE_ENABLED", True),
+        (37, "GUILD_INCIDENT_ALERT_MODE_DISABLED", True),
+        (38, "GUILD_INCIDENT_REPORT_RAID", True),
+        (39, "GUILD_INCIDENT_REPORT_FALSE_ALARM", True),
+        (40, "GUILD_DEADCHAT_REVIVE_PROMPT", True),
+        (41, "CUSTOM_GIFT", True),
+        (42, "GUILD_GAMING_STATS_PROMPT", True),
+        (44, "PURCHASE_NOTIFICATION", True),
+        (46, "POLL_RESULT", True),
+        (47, "CHANGELOG", True),
+        (48, "NITRO_NOTIFICATION", True),
+        (49, "CHANNEL_LINKED_TO_LOBBY", True),
+        (50, "GIFTING_PROMPT", True),
+        (51, "IN_GAME_MESSAGE_NUX", True),
+        (52, "GUILD_JOIN_REQUEST_ACCEPT_NOTIFICATION", True),
+        (53, "GUILD_JOIN_REQUEST_REJECT_NOTIFICATION", True),
+        (54, "GUILD_JOIN_REQUEST_WITHDRAWN_NOTIFICATION", True),
+        (55, "HD_STREAMING_UPGRADED", True),
+        (58, "REPORT_TO_MOD_DELETED_MESSAGE", True),
+        (59, "REPORT_TO_MOD_TIMEOUT_USER", True),
+        (60, "REPORT_TO_MOD_KICK_USER", True),
+        (61, "REPORT_TO_MOD_BAN_USER", True),
+        (62, "REPORT_TO_MOD_CLOSED_REPORT", True),
+        (63, "EMOJI_ADDED", True),
+        (64, "PREMIUM_GROUP_INVITE", False),
+        (65, "VOICE_SESSION", True),
+        (66, "GUILD_BOOST_UPSELL", True),
+        (67, "FRIEND_REQUEST_ACCEPTED", True),
+        (68, "MEDIA_MENTION_MESSAGE", True),
+    ],
+)
+def test_message_type_mapping(value, name, deletable):
+    message_type = MessageType(value)
+
+    assert message_type.name == name
+    assert message_type.deletable is deletable
+
+
+def test_fetch_messages_maps_friend_request_accepted_type(monkeypatch):
+    api = DiscordAPI(token="dummy-token")
+    responses = [
+        [
+            {
+                "id": "200",
+                "timestamp": "2026-01-02T00:00:00.000000+00:00",
+                "type": 67,
+                "author": {"id": "u1"},
+                "reactions": [],
+            }
+        ],
+        [],
+    ]
+
+    monkeypatch.setattr(api, "_request", lambda *_, **__: responses.pop(0))
+
+    message = list(api.fetch_messages(channel_id="c1", fetch_sleep_time_range=(0, 0)))[0]
+
+    assert message["type"] is MessageType.FRIEND_REQUEST_ACCEPTED
+    assert message["type"].deletable is True
+
+
+def test_unknown_numeric_message_type_warns_and_remains_non_deletable(caplog):
+    with caplog.at_level(logging.WARNING, logger="MessageType"):
+        message_type = MessageType(999)
+        MessageType(999)
+
+    assert message_type.name == "UNKNOWN_999"
+    assert message_type.deletable is False
+    warnings = [record for record in caplog.records if "unrecognized message type 999" in record.message]
+    assert len(warnings) == 2
 
 
 def test_fetch_messages_stops_at_max_messages(monkeypatch):


### PR DESCRIPTION
## Summary

- add Discord message types 64 through 68
- align message types 8 through 11 with their documented names
- recognize `FRIEND_REQUEST_ACCEPTED` as deletable
- mark `PREMIUM_GROUP_INVITE` and `PREMIUM_REFERRAL` as non-deletable
- keep `AUTO_MODERATION_ACTION` non-deletable because deletion requires the `MANAGE_MESSAGES` permission
- retain deprecated `EMOJI_ADDED` support for historical messages
- handle future unknown numeric message types without crashing, treating them as non-deletable by default

## Verification

- audited all 61 currently documented message types
- retained historical support for message type 63
- `python -m pytest -q`: 455 passed
- `git diff --check`: clean

## Reference

https://docs.discord.food/resources/message#message-type